### PR TITLE
feat: add TalorData SERP API support

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,6 +4,7 @@ GOOGLE_KEY=your_google_key
 SERPAPI_KEY=your_serpapi_key
 SERPER_KEY=your_serper_key
 BING_KEY=your_bing_key
+TALORDATA_KEY=your_talordata_api_key
 SEARXNG_BASE_URL=your_searxng_base_url
 SEARCH_SERVICE=your_search_service
 MAX_RESULTS=the results of search

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ http://localhost:3014/v1/chat/completions
 
 | 环境变量             | 是否必须 | 描述                                                                                                                  | 例子                                                                             |
 | -------------------- | -------- | --------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `SEARCH_SERVICE`   | Yes      | 你的搜索服务，选择什么服务，就需要配置什么服务的key | `search1api, google, bing, serpapi, serper, duckduckgo, searxng`               |
+| `SEARCH_SERVICE`   | Yes      | 你的搜索服务，选择什么服务，就需要配置什么服务的key | `search1api, google, bing, serpapi, serper, duckduckgo, searxng, talordata`               |
 | `APIBASE`          | No       | 三方代理地址                                                                                                         | `https://api.openai.com, https://api.moonshot.cn, https://api.groq.com/openai` |
 | `MAX_RESULTS`      | Yes      | 搜索结果条数                                                                                                          | `10`                                                                           |
 | `CRAWL_RESULTS`    | No       | 要进行深度搜索（搜索后获取网页正文）的数量，目前仅支持 search1api，深度速度会慢                                       | `1`                                                                            |
@@ -122,6 +122,7 @@ http://localhost:3014/v1/chat/completions
 | `SERPAPI_KEY`      | No       | 如选serpapi必填，免费100次/月，点击[链接](https://serpapi.com/) 注册                                              | `xxx`                                                                          |
 | `SERPER_KEY`       | No       | 如选serper必填，6个月免费额度2500次，点击[链接](https://serper.dev/) 注册                                         | `xxx`                                                                          |
 | `SEARXNG_BASE_URL` | No       | 如选searxng必填，填写自建searXNG服务域名，需打开 json 模式，教程参考[链接](https://github.com/searxng/searxng) | `https://search.xxx.xxx`                                                                         |
+| `TALORDATA_KEY` | No | 如选talordata必填，注册免费额度，点击[链接](https://talordata.com/?campaignid=W5d72kLodDV5TWxb&utm_source=search2ai&utm_term=search2ai) | `xxx` |
 | `OPENAI_TYPE`      | No       | openai供给来源，默认为openai                                                                                          | `openai, azure`                                                                |
 | `RESOURCE_NAME`    | No       | 如选azure必填                                                                                                         | `xxxx`                                                                         |
 | `DEPLOY_NAME`      | No       | 如选azure必填                                                                                                         | `gpt-35-turbo`                                                                 |

--- a/units/news.js
+++ b/units/news.js
@@ -115,6 +115,29 @@ async function news(query) {
             }));
             break;
 
+        case "talordata":
+          const talordataUrl = "https://api.talordata.com/serp";
+          const talordataResponse = await fetch(talordataUrl, {
+            method: "POST",
+            headers: {
+              "Authorization": `Bearer ${process.env.TALORDATA_KEY}`,
+              "Content-Type": "application/json"
+            },
+            body: JSON.stringify({
+              q: query,
+              source: "google",
+              num: process.env.MAX_RESULTS || 10,
+              news: true
+            })
+          });
+          const talordataData = await talordataResponse.json();
+          results = (talordataData.news || []).slice(0, process.env.MAX_RESULTS).map((item) => ({
+            title: item.title,
+            link: item.link,
+            snippet: item.snippet
+          }));
+          break;
+
         default:
           console.error(`不支持的搜索服务: ${process.env.SEARCH_SERVICE}`);
           return `不支持的搜索服务: ${process.env.SEARCH_SERVICE}`;

--- a/units/search.js
+++ b/units/search.js
@@ -114,7 +114,29 @@ async function search(query) {
               snippet: item.content
             }));
             break;
-            
+
+        case "talordata":
+          const talordataUrl = "https://api.talordata.com/serp";
+          const talordataResponse = await fetch(talordataUrl, {
+            method: "POST",
+            headers: {
+              "Authorization": `Bearer ${process.env.TALORDATA_KEY}`,
+              "Content-Type": "application/json"
+            },
+            body: JSON.stringify({
+              q: query,
+              source: "google",
+              num: process.env.MAX_RESULTS || 10
+            })
+          });
+          const talordataData = await talordataResponse.json();
+          results = (talordataData.organic || []).slice(0, process.env.MAX_RESULTS).map((item) => ({
+            title: item.title,
+            link: item.link,
+            snippet: item.snippet
+          }));
+          break;
+
         default:
           console.error(`不支持的搜索服务: ${process.env.SEARCH_SERVICE}`);
           return `不支持的搜索服务: ${process.env.SEARCH_SERVICE}`;


### PR DESCRIPTION
Added [TalorData SERP API](https://talordata.com/?campaignid=W5d72kLodDV5TWxb&utm_source=search2ai&utm_term=search2ai) as a new search backend option.

Changes:
- units/search.js: add "talordata" case for web search
- units/news.js: add "talordata" case for news search
- .env.template: add TALORDATA_KEY variable
- README.md: document TalorData in env vars + SEARCH_SERVICE list

Sign up: [TalorData](https://talordata.com/?campaignid=W5d72kLodDV5TWxb&utm_source=search2ai&utm_term=search2ai)